### PR TITLE
correcting style injection scope as well as minor visual improvements

### DIFF
--- a/client/src/components/Footer.svelte
+++ b/client/src/components/Footer.svelte
@@ -1,5 +1,5 @@
 <footer>
-	<div class="container">
+	<div class="container shadow-high">
 		<section class="encouragement">
 			<h1 class="title-5">Hi, Nacho Here 😄! I Think There's Something You Should Know:</h1>
 			<h2 class="title-6">Typescale Garden is an Open Source Project!</h2>
@@ -35,6 +35,7 @@
 			<p class="body-1"><b>Links of Interest</b></p>
 			<nav>
 				<ul class="body-2">
+					<li><a href="/">Home</a></li>
 					<li><a href="/privacy">Privacy Policy</a></li>
 					<li>
 						<a target="_blank" href="https://github.com/ignacio-nacho-barbano/typescale-garden"
@@ -46,6 +47,9 @@
 							>GitHub Sponsors</a
 						>
 					</li>
+					<li>
+						<a target="_blank" href="mailto:nacho.barbano.dev@gmail.com">Support Mail</a>
+					</li>
 				</ul>
 			</nav>
 		</div>
@@ -55,12 +59,11 @@
 <style lang="scss">
 	footer {
 		width: 100%;
-		background: $c-primary;
-		border-top: solid $c-accent $lw;
+
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		padding: $s6 0;
+		padding: $s4 0;
 
 		@media ($bp-m) {
 			padding: $s7 $s4;
@@ -69,7 +72,11 @@
 		& > div {
 			display: flex;
 			flex-wrap: wrap;
+			padding: $sd5;
 			gap: $sd6;
+			border-radius: $s5;
+			background: $c-primary;
+			border: solid $c-accent $lw;
 		}
 	}
 </style>

--- a/client/src/components/Sidebar/Sidebar.svelte
+++ b/client/src/components/Sidebar/Sidebar.svelte
@@ -14,35 +14,37 @@
 	class:open={$sidebarOpen}
 	class="side-bar {$windowWidth < 1000 ? 'shadow-high' : ''}"
 >
-	<div class="settings-title">
-		<h2 class="title-6">Settings</h2>
-	</div>
+	<div class="scrollable-area">
+		<div class="settings-title">
+			<h2 class="title-6">Settings</h2>
+		</div>
 
-	{#if PUB_FEATURE_FLAGS?.includes("load-save")}
-		<Accordion bind:open={$accordionStates.file}>
-			<span slot="title">File</span>
-			<div slot="content" class="file-buttons">
-				<LoadControl />
-				<SaveControl />
-			</div>
+		{#if PUB_FEATURE_FLAGS?.includes("load-save")}
+			<Accordion bind:open={$accordionStates.file}>
+				<span slot="title">File</span>
+				<div slot="content" class="file-buttons">
+					<LoadControl />
+					<SaveControl />
+				</div>
+			</Accordion>
+		{/if}
+		<!-- <Button leadIcon="Parameters" /> -->
+		<Accordion bind:open={$accordionStates.parameters}>
+			<span slot="title">Typescale</span>
+			<Parameters slot="content" />
 		</Accordion>
-	{/if}
-	<!-- <Button leadIcon="Parameters" /> -->
-	<Accordion bind:open={$accordionStates.parameters}>
-		<span slot="title">Typescale</span>
-		<Parameters slot="content" />
-	</Accordion>
-	<!-- experimental feature, needs development -->
-	{#if PUB_FEATURE_FLAGS?.includes("contrast")}
-		<Accordion bind:open={$accordionStates.contrast}>
-			<span slot="title">Contrast</span>
-			<Contrast slot="content" />
+		<!-- experimental feature, needs development -->
+		{#if PUB_FEATURE_FLAGS?.includes("contrast")}
+			<Accordion bind:open={$accordionStates.contrast}>
+				<span slot="title">Contrast</span>
+				<Contrast slot="content" />
+			</Accordion>
+		{/if}
+		<Accordion bind:open={$accordionStates.export}>
+			<span slot="title">Export</span>
+			<Export slot="content" />
 		</Accordion>
-	{/if}
-	<Accordion bind:open={$accordionStates.export}>
-		<span slot="title">Export</span>
-		<Export slot="content" />
-	</Accordion>
+	</div>
 </section>
 
 <style lang="scss">
@@ -58,20 +60,25 @@
 
 		position: fixed;
 		z-index: 5;
-		top: $s6;
-		bottom: 0;
+		top: calc($s6 + $s3);
+		bottom: $s4;
 		left: 0;
 		border-radius: 0 $s5 $s5 0;
 		min-width: $width;
 		max-width: $width;
-		display: flex;
-		flex-direction: column;
-		padding: 0 0 $s5;
-		overflow: auto;
+		overflow: hidden;
 		border-right: solid $lw $c-primary;
 		margin-left: calc(-1 * $width);
 		background: $c-base;
 		transition: margin-left 500ms ease-in-out;
+
+		.scrollable-area {
+			display: flex;
+			flex-direction: column;
+			overflow: auto;
+			height: 100%;
+			width: 100%;
+		}
 
 		&.open {
 			margin-left: 0;

--- a/client/src/components/Sidebar/Sidebar.svelte
+++ b/client/src/components/Sidebar/Sidebar.svelte
@@ -9,11 +9,7 @@
 	import Parameters from "./Parameters.svelte";
 </script>
 
-<section
-	id="sidebar"
-	class:open={$sidebarOpen}
-	class="side-bar {$windowWidth < 1000 ? 'shadow-high' : ''}"
->
+<section id="sidebar" class:open={$sidebarOpen} class="side-bar shadow-high">
 	<div class="scrollable-area">
 		<div class="settings-title">
 			<h2 class="title-6">Settings</h2>
@@ -67,7 +63,8 @@
 		min-width: $width;
 		max-width: $width;
 		overflow: hidden;
-		border-right: solid $lw $c-primary;
+		border: solid $lw $c-primary;
+		border-left: none;
 		margin-left: calc(-1 * $width);
 		background: $c-base;
 		transition: margin-left 500ms ease-in-out;
@@ -89,8 +86,11 @@
 		}
 
 		@media ($bp-xl) {
+			border-top: none;
+			border-bottom: none;
 			border-radius: 0;
 			position: unset;
+			box-shadow: none;
 		}
 	}
 

--- a/client/src/components/SvelteHead.svelte
+++ b/client/src/components/SvelteHead.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	export let title: string = "Typescale Garden";
 	export let description: string =
-		"A typescale creation tool. It allows you to generate a typographic scale and export css and figma tokens out of it, directly into design trough the official figma plugin. A useful tool for people working with design systems.";
-	const ogImage = "../../tg-logo.png";
+		"Typescale Garden is a typescale creation tool. It allows you to generate a typographic scale and export css and figma tokens out of it, directly into design trough the official figma plugin. A useful tool for people working with design systems.";
+	const ogImage =
+		"https://raw.githubusercontent.com/ignacio-nacho-barbano/typescale-garden/main/client/static/logo.svg";
 </script>
 
 <svelte:head>
@@ -14,7 +15,7 @@
 	<meta property="og:url" content="https://typescalegarden.uy" />
 	<meta property="og:image" content={ogImage} />
 	<meta property="og:image:secure_url" content={ogImage} />
-	<meta property="og:image:type" content="image/png" />
+	<meta property="og:image:type" content="image/svg+xml" />
 	<meta property="og:image:width" content="144" />
 	<meta property="og:image:height" content="144" />
 	<meta property="og:image:alt" content="Typescale Garden Logo" />

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -10,8 +10,11 @@
 	import { storedTypescales } from "../stores/typescales";
 	import type { LayoutData } from "./$types";
 	import Footer from "../components/Footer.svelte";
+	import { navigating } from "$app/stores";
 
 	export let data: LayoutData;
+
+	let scrollContainer: HTMLElement | null = null;
 
 	let innerWidth: number;
 
@@ -24,10 +27,12 @@
 
 	$: updateWidthDependencies(innerWidth);
 
+	$: if ($navigating) {
+		scrollContainer?.scroll({ top: 0, behavior: "smooth" });
+	}
+
 	onMount(() => {
-		// if (data.typescales) {
-		// 	storedTypescales.set(data.typescales);
-		// }
+		scrollContainer = document.getElementById("scrollable-area");
 	});
 </script>
 
@@ -40,9 +45,9 @@
 >
 	<Sidebar />
 
-	<div class="scrollable-area">
+	<div id="scrollable-area">
+		<TopBar />
 		<main id="main-content">
-			<TopBar />
 			<div
 				class="grid-overlay"
 				style="display: {$visibleGrid
@@ -76,7 +81,7 @@
 		position: relative;
 	}
 
-	.scrollable-area {
+	#scrollable-area {
 		flex: 1 1;
 		overflow: auto;
 		max-width: 100dvw;

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -5,46 +5,31 @@
 	import { cssCode } from "../stores/config";
 	import { routes } from "./routes";
 	import { Breakpoints } from "../constants";
+	const wrapperClass = "styles-injection-wrapper";
 
-	const tableStyles = derived([cssCode, mobileView], ([code, mobile]) => {
+	const userGeneratedStyles = derived([cssCode, mobileView], ([code, mobile]) => {
 		let styles = code;
 		let minWidthOverride = "@media (min-width: ";
 		minWidthOverride += mobile ? "100000" : "1";
-		let bodyOverride = ".how-it-works-page.main-page-section {";
-		bodyOverride += mobile
-			? `
-		max-width: 400px;
-		min-width: unset;
-		margin: 32px 0;
-		padding: 52px 32px;
-		`
-			: "\n";
+		// opens a new scope
+		const bodyOverride = `
+.${wrapperClass} {
+	.how-it-works-page.main-page-section {`;
+		/* intentionally missing a closing bracket for wrapper class
+		and the selector replacing the body, see comment below */
 
-		styles = styles.replaceAll("body {", bodyOverride);
 		styles = styles.replaceAll(/@media \(min-width: \d+/g, minWidthOverride);
+		styles = styles.replace("body {", bodyOverride);
+
+		// closes a new scope at the end of the file
+		styles += "}\n}";
 
 		return styles;
 	});
 </script>
 
-<div class="styles-injection-wrapper">
-	{@html `
-	<style>
-		${$tableStyles}
-	.styles-injection-wrapper {
-		.how-it-works-page.mobileView {
-			.text-and-image {
-			flex-direction: column !important;
-		}
-
-			@media (min-width: ${Breakpoints.M}px) {
-			border: var(--c-accent) solid 1px;
-			border-radius: 32px;
-		}
-	}
-		
-	}
-		</style>`}
+<div class={wrapperClass}>
+	{@html `<style>${$userGeneratedStyles}</style>`}
 	<section
 		id={routes[0].id}
 		class:mobileView={$mobileView}
@@ -153,12 +138,25 @@
 	.styles-injection-wrapper {
 		display: contents;
 	}
+
 	#how-it-works {
 		overflow: hidden;
 		max-width: 100%;
-		& > * {
-			margin-left: min($s5, auto);
-			margin-right: min($s5, auto);
+
+		&.mobileView {
+			min-width: unset;
+			margin: $s5 0;
+			padding: $s6 $s5;
+
+			.text-and-image {
+				flex-direction: column;
+			}
+
+			@media ($bp-s) {
+				max-width: 400px;
+				border: var(--c-accent) solid $lw;
+				border-radius: $s5;
+			}
 		}
 	}
 

--- a/client/src/routes/privacy/+page.svelte
+++ b/client/src/routes/privacy/+page.svelte
@@ -29,7 +29,7 @@
 		</li>
 	</ul>
 
-	<h3>3. How We Use Your Data</h3>
+	<h3 class="space-text-above">3. How We Use Your Data</h3>
 	<h4>We use the collected data for the following purposes:</h4>
 	<ul>
 		<li><strong>User Authentication:</strong> Utilizing Auth0 for secure user authentication.</li>
@@ -40,7 +40,7 @@
 		</li>
 	</ul>
 
-	<h3>4. Data Security</h3>
+	<h3 class="space-text-above">4. Data Security</h3>
 	<h4>We prioritize the security of your data:</h4>
 	<ul>
 		<li>
@@ -52,7 +52,7 @@
 		</li>
 	</ul>
 
-	<h3>5. Data Retention</h3>
+	<h3 class="space-text-above">5. Data Retention</h3>
 	<p>
 		We retain user data for the duration necessary for the outlined purposes. Users can request data
 		deletion by contacting <strong
@@ -75,3 +75,9 @@
 		>.
 	</p>
 </article>
+
+<style lang="scss">
+	article * {
+		max-width: 768px;
+	}
+</style>

--- a/client/src/scss/global-classes.scss
+++ b/client/src/scss/global-classes.scss
@@ -73,6 +73,11 @@
 	margin-right: $s5;
 	max-width: 1168px;
 
+	& > * {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
 	@media screen and ($bp-m) {
 		margin-left: $s6;
 		margin-right: $s6;
@@ -83,7 +88,7 @@
 		margin-right: $s7;
 	}
 
-	@media screen and ($bp-xxxl) {
+	@media screen and ($bp-xxl) {
 		margin-left: $s8;
 		margin-right: $s8;
 	}

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -61,7 +61,7 @@ export const availableWeights = derived(currentFont, ($currentFont) => {
 });
 
 export const headingsInitialWeight = writable(700);
-export const headingsFinalWeight = writable(500);
+export const headingsFinalWeight = writable(300);
 
 availableWeights.subscribe(($aw) => {
 	if (!$aw.includes(get(headingsInitialWeight)))


### PR DESCRIPTION
# Description

Previousy, when injecting styles, the UI of the app would be impacted, to fix this, a scope was added to the injected stlyes. Momentanously that broke font injection as the css' @import wasn't happenning at the top of the style block. This fixes both. Also I fixed #26 in the way.

# Related Issue

Closes #26

# Changes Made

- Changed how the scope for the injected styles works
- Sidebar style improvements
- General alignment of the content of the container class
- Now the app scrolls back to top when navigation occurs

# Screenshots
![image](https://github.com/ignacio-nacho-barbano/typescale-garden/assets/48802984/06848621-3bed-41fa-a00d-caf0ea12ecc8)

![image](https://github.com/ignacio-nacho-barbano/typescale-garden/assets/48802984/0f0175c0-ef41-46cf-aca3-d32f66360cee)


![image](https://github.com/ignacio-nacho-barbano/typescale-garden/assets/48802984/dc3528c8-fc3f-46fb-9b24-73d42e3bfd19)

# Checklist

- [x] Tested the changes locally
- [x] Resolved any merge conflicts
- [x] Followed coding style guidelines
- [ ] Updated documentation if necessary

# Additional Notes

[Include any additional information or context that may be helpful for reviewers.]
