### PR TITLE
fix(client): show a skeleton while auth resolves state 

### DIFF
--- a/client/src/components/TopBar.svelte
+++ b/client/src/components/TopBar.svelte
@@ -7,6 +7,7 @@
 	import Icon from "./Icon.svelte";
 	import Switch from "./Switch.svelte";
 	import UserControls from "./UserControls.svelte";
+	import UserControlsSkeleton from "./UserControlsSkeleton.svelte";
 	import { logIn } from "../functions";
 </script>
 
@@ -31,7 +32,14 @@
 		<Switch size="s" name="mobile-view" label="Mobile View" bind:value={$mobileView} />
 	</div>
 
-	{#if $authState.isAuthenticated}
+	<!--
+		Three branches, not two: until the silent login answers we know nothing, and
+		rendering the log-in buttons in that gap flashes "logged out" at users who are
+		not. The SSR pass always lands here, since auth is browser-only.
+	-->
+	{#if $authState.isResolving}
+		<UserControlsSkeleton />
+	{:else if $authState.isAuthenticated}
 		<UserControls />
 	{:else}
 		<Button

--- a/client/src/components/UserControlsSkeleton.svelte
+++ b/client/src/components/UserControlsSkeleton.svelte
@@ -1,0 +1,60 @@
+<!--
+	Stands in for UserControls while the silent login is still resolving — including in
+	the SSR pass, where auth is never known. Geometry mirrors UserControls (40px avatar,
+	the name hidden below $bp-l, room for the chevron) so the swap costs no layout shift.
+-->
+<div class="user-controls-skeleton" aria-hidden="true">
+	<div class="avatar" />
+	<div class="name" />
+	<div class="chevron" />
+</div>
+<span class="visually-hidden" aria-live="polite">Loading account</span>
+
+<style lang="scss">
+	.user-controls-skeleton {
+		height: 40px;
+		display: flex;
+		align-items: center;
+		gap: $s3;
+		flex: 0 0 auto;
+	}
+
+	.avatar {
+		@include skeleton;
+		height: 100%;
+		aspect-ratio: 1;
+		flex: 0 0 auto;
+		border-radius: 50%;
+	}
+
+	// Matches #user-name in UserControls: absent until $bp-l.
+	.name {
+		@include skeleton;
+		display: none;
+
+		@media ($bp-l) {
+			display: block;
+			width: 72px;
+			height: $s3;
+		}
+	}
+
+	// Placeholder for the <Icon>expand_more</Icon>, which renders at 24px.
+	.chevron {
+		@include skeleton;
+		width: 24px;
+		height: $s3;
+	}
+
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		padding: 0;
+		overflow: hidden;
+		clip: rect(0 0 0 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>

--- a/client/src/functions/getUserData.ts
+++ b/client/src/functions/getUserData.ts
@@ -1,30 +1,41 @@
 import type { Auth0Client } from "@auth0/auth0-spa-js";
 import { authToken, user } from "../stores/auth";
 
+/**
+ * Resolves the `user` store to either a user or `null` — never leaves it `undefined`.
+ * The UI treats `undefined` as "still resolving" and renders a placeholder, so any
+ * path out of here that skipped the store would leave that placeholder up for good.
+ */
 export async function getUserData(client: Auth0Client) {
-	if (client) {
-		if (
-			location.search.includes("state=") &&
-			(location.search.includes("code=") || location.search.includes("error="))
-		) {
-			await client.handleRedirectCallback();
-			window.history.replaceState({}, document.title, "/");
-		}
-
-		try {
-			const token = await client.getTokenSilently();
-			authToken.set(token);
-
-			if (token) {
-				const loggedUser = (await client.getUser()) || null;
-
-				user.set(loggedUser);
-
-				return loggedUser;
-			}
-		} catch (e) {
-			user.set(null);
-			return null;
-		}
+	if (!client) {
+		user.set(null);
+		return null;
 	}
+
+	if (
+		location.search.includes("state=") &&
+		(location.search.includes("code=") || location.search.includes("error="))
+	) {
+		await client.handleRedirectCallback();
+		window.history.replaceState({}, document.title, "/");
+	}
+
+	try {
+		const token = await client.getTokenSilently();
+		authToken.set(token);
+
+		if (token) {
+			const loggedUser = (await client.getUser()) || null;
+
+			user.set(loggedUser);
+
+			return loggedUser;
+		}
+	} catch (e) {
+		user.set(null);
+		return null;
+	}
+
+	user.set(null);
+	return null;
 }

--- a/client/src/functions/logIn.ts
+++ b/client/src/functions/logIn.ts
@@ -1,7 +1,16 @@
 import type { Auth0Client } from "@auth0/auth0-spa-js";
+import { showNotification } from "../stores/notifications";
 
 export function logIn(e: Event, authClientState: Auth0Client, signUp?: boolean) {
 	e.preventDefault();
+
+	// The page is interactive before the Auth0 client exists — auth is resolved off the
+	// critical path (see `resolveAuth` in routes/+layout.ts), and the log-in buttons also
+	// render when client creation failed outright. Clicking in that window used to throw.
+	if (!authClientState) {
+		showNotification("Still connecting to the login service — please try again in a moment.");
+		return;
+	}
 
 	let config;
 

--- a/client/src/routes/+layout.ts
+++ b/client/src/routes/+layout.ts
@@ -5,7 +5,12 @@ import { getUserData } from "../functions";
 import { ENV } from "../services/env";
 import { logError } from "../services/errorLogger";
 import { initAnonymousAnalysis } from "../services/hotjar";
-import { authClient } from "../stores/auth";
+import {
+	AUTH_PLACEHOLDER_GRACE_MS,
+	authClient,
+	authResolutionTimedOut,
+	user
+} from "../stores/auth";
 import { PUB_API_URL } from "$env/static/public";
 
 const authConfig: Auth0ClientOptions = {
@@ -23,6 +28,39 @@ export interface LayoutData {
 	error?: unknown;
 }
 
+/**
+ * Resolves auth **off the critical path** — deliberately not awaited by `load`.
+ *
+ * `createAuth0Client` awaits `checkSession()` internally, which is a hidden-iframe
+ * silent auth: 60s timeout, 3 retries. Whenever third-party cookies are blocked or the
+ * tenant is slow, that stalls for a long time. Awaiting it in `load` blocks hydration,
+ * and a page that has not hydrated cannot re-render — so the top bar would be pinned to
+ * whatever the SSR pass emitted for the entire wait, placeholder included.
+ *
+ * Fire-and-forget instead: the `user` store settles whenever the silent login lands and
+ * the UI swaps the placeholder for the real state then. Consumers are already built for
+ * this — `stores/fetch.ts` rebuilds its axios instance when the token arrives, and
+ * `stores/typescales.ts` waits on `silentLoginReady` before fetching.
+ */
+async function resolveAuth() {
+	// Caps how long the UI will sit on a placeholder if the iframe never answers.
+	const graceTimer = setTimeout(() => authResolutionTimedOut.set(true), AUTH_PLACEHOLDER_GRACE_MS);
+
+	try {
+		const client = await createAuth0Client(authConfig);
+		authClient.set(client);
+
+		await getUserData(client);
+	} catch (err) {
+		console.error("Unable to create auth client:\n", err);
+		// Settle to "anonymous". The UI shows a placeholder while `user` is `undefined`,
+		// so a silent return here would leave it up until the grace period expires.
+		user.set(null);
+	} finally {
+		clearTimeout(graceTimer);
+	}
+}
+
 /** @type {import('./$types').LayoutLoad} */
 export async function load({ fetch }): Promise<LayoutData> {
 	if (ENV.IS_BROWSER) {
@@ -34,20 +72,11 @@ export async function load({ fetch }): Promise<LayoutData> {
 			}
 		}
 
-		try {
-			const client = await createAuth0Client(authConfig);
-			authClient.set(client);
+		// Intentionally not awaited — see resolveAuth's comment.
+		resolveAuth();
 
-			await getUserData(client);
-
-			return {
-				successfulLoad: true
-			};
-		} catch (err) {
-			console.error("Unable to create auth client:\n", err);
-		}
 		return {
-			successfulLoad: false
+			successfulLoad: true
 		};
 	} else {
 		return {

--- a/client/src/scss/animations.scss
+++ b/client/src/scss/animations.scss
@@ -55,6 +55,17 @@
 	}
 }
 
+@keyframes skeleton-pulse {
+	0%,
+	100% {
+		opacity: 0.35;
+	}
+
+	50% {
+		opacity: 0.7;
+	}
+}
+
 .fade-in {
 	animation: fade 600ms both;
 }

--- a/client/src/scss/design-system.scss
+++ b/client/src/scss/design-system.scss
@@ -91,3 +91,17 @@ $sd9: var(--size-9);
 @mixin shadow-high {
 	box-shadow: var(--shadow-elevation-high);
 }
+
+/// Placeholder shape for content that has not resolved yet. Pulses, unless the user
+/// asked for less motion, in which case it holds a flat mid tone.
+/// `skeleton-pulse` is declared in animations.scss.
+@mixin skeleton {
+	background: $c-accent;
+	border-radius: $s3;
+	animation: skeleton-pulse 1600ms ease-in-out infinite;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+		opacity: 0.45;
+	}
+}

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -1,12 +1,40 @@
 import type { Auth0Client, User } from "@auth0/auth0-spa-js";
 import { derived, writable } from "svelte/store";
 
+/**
+ * How long auth-dependent UI is allowed to show a placeholder before it gives up and
+ * renders the logged-out state. A healthy silent login lands in well under a second;
+ * this only bites when the hidden auth iframe stalls — blocked third-party cookies, an
+ * unreachable tenant — where auth0-spa-js waits 60s per attempt and retries 3 times.
+ * Without a ceiling the placeholder could outlive the user's patience by minutes.
+ */
+export const AUTH_PLACEHOLDER_GRACE_MS = 3000;
+
 export const authClient = writable<Auth0Client>();
+
+/** Set once the grace period above has elapsed with `user` still unresolved. */
+export const authResolutionTimedOut = writable(false);
+
+/**
+ * Three-state on purpose: `undefined` means the silent login has not answered yet,
+ * `null` means it answered "nobody". Anything that renders auth-dependent UI must
+ * branch on all three — see `isResolving` below — or a logged-in user gets a flash
+ * of the logged-out UI. During SSR it is always `undefined`, since `getUserData`
+ * only ever runs in the browser.
+ */
 export const user = writable<User | null>();
 export const authToken = writable<string>();
 export const idToken = writable<string>();
-export const authState = derived([user], ([user]) => {
+export const authState = derived([user, authResolutionTimedOut], ([user, timedOut]) => {
 	return {
+		/**
+		 * True until the silent login resolves one way or the other (or the grace
+		 * period runs out). This is what the SSR pass always sees, so UI keyed on it
+		 * renders a placeholder in the served HTML rather than committing to "logged
+		 * out". Every failure path in `getUserData` / `+layout.ts` settles `user`, and
+		 * the timeout backstops the paths that never settle at all.
+		 */
+		isResolving: user === undefined && !timedOut,
 		silentLoginReady: user !== undefined,
 		isAuthenticated: !!user?.email
 	};


### PR DESCRIPTION
The top bar committed to "logged out" before the silent login had answered, so a signed-in user got a flash of Log In / Register on every load — including in the SSR HTML, where auth is never knowable.

Two things had to change. `authState` only had two states, so make the three-state nature of `user` explicit (`undefined` = unanswered, `null` = nobody) and expose `isResolving`; the top bar now branches three ways and renders a placeholder while unresolved.

That alone does not work, though: `+layout.ts` awaited `createAuth0Client`, which awaits `checkSession()` internally — a hidden-iframe silent auth with a 60s timeout and 3 retries. In a universal `load` that blocks hydration, and an unhydrated page cannot re-render, so the placeholder pinned permanently instead of the buttons. Auth now resolves off the critical path in a deliberately un-awaited `resolveAuth()`. Safe because `successfulLoad` is read nowhere and both downstream consumers already handle late auth — `fetch.ts` rebuilds its axios instance on token change, and `typescales.ts` gates on `silentLoginReady`.

Also harden the paths that could strand the placeholder: `getUserData` now always settles `user` (it returned early on a falsy client or token), and `logIn` no longer throws when clicked before `authClient` exists — newly reachable now that the page is interactive earlier.

The 3s grace period is a ceiling, not a target: if a real silent login exceeds it the flash returns, just delayed. The alternative was an unbounded placeholder.

> ## Read and Delete this before committing
>
> ### Before submitting the PR, please make sure you do the following
>
> 1. Contributor license agreement
>    For us it's important to have the agreement of our contributors to use their work, whether it be code or documentation. Therefore, we are asking all contributors to sign a contributor license agreement (CLA) as commonly accepted in most open source projects. **Just open the pull request and our CLA bot will prompt you briefly.**
>
> 2. Please check our [contribution guidelines](https://github.com/ignacio-nacho-barbano/typescale-garden?tab=coc-ov-file#readme) for guidance.

<!-- Delete Everything Above -->

# Description

[Provide a brief description of the changes introduced by this pull request.]

# Related Issue

Closes #[Issue Number]

# Changes Made

- [List the main changes or features implemented in bullet points.]

# Screenshots

[Include any relevant screenshots or visuals to assist in the review process.]

# Checklist

- [ ] Tested the changes locally
- [ ] Resolved any merge conflicts
- [ ] Followed coding style guidelines
- [ ] Updated documentation if necessary

# Additional Notes

[Include any additional information or context that may be helpful for reviewers.]
