### PR TITLE
ci: PR gate for the non-browser checks, and auto deploy the Worker on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,216 @@
+# The non-browser PR gate: everything `e2e.yml` does not cover.
+#
+# Until now the repo's only check was the hermetic Playwright suite, which drives the client's
+# dev server. That leaves a lot unproven on a PR — nothing type checked the Worker, nothing
+# built the client *bundle* (the dev server never produces one), and nothing ran the unit tests.
+# A broken `server/` reached main and was only caught by `deploy-server.yml` after merge, at
+# which point it had already deployed; a broken client bundle was caught by Cloudflare Pages,
+# i.e. also after merge.
+#
+# What is deliberately NOT gated: `client#check` (18 svelte-check errors) and `client#lint`
+# (the client's `.eslintrc.cjs` cannot load under eslint 10, which dropped `.eslintrc` support
+# entirely, plus wide prettier drift). Both are long-standing and orthogonal to any given PR —
+# gating on them would make this workflow permanently red and therefore ignored, which is the
+# same reasoning that keeps them out of `e2e.yml`. They run anyway in `known-failing`, which
+# cannot fail the workflow, so the drift stays visible and the day someone fixes the eslint
+# config it goes green on its own.
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push supersedes the run in flight for the same ref — unlike `deploy-server.yml`,
+# nothing here has a side effect worth protecting mid-flight.
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# Throwaway values, inlined into the CI bundle and never deployed — Pages does its own build
+# with the real values from its dashboard. They exist because `$env/static/public` is a virtual
+# module built from what is defined, so a name the client imports and CI does not define is a
+# *build error*, and `client/src/services/env.ts` additionally throws when `PUB_API_URL` is
+# falsy. That throw is why `client#test` fails without them: `stores/config.test.ts` imports
+# `errorLogger` → `sentry` → `env` and dies on collection.
+#
+# Keep in step with `E2E_PUB_ENV` in `e2e/support/env.ts`, which is the same list for the same
+# reason. `PUB_APP_ENV: local` and an empty `PUB_SENTRY_DSN` are each independently sufficient
+# to keep a CI build silent: `SENTRY_ENABLED` is `Boolean(DSN) && !IS_LOCAL`.
+env:
+  PUB_APP_ENV: local
+  PUB_API_URL: http://localhost:5173/mock-api
+  PUB_AUTH_DOMAIN: http://localhost:5173/idp
+  PUB_AUTH_CLIENT_ID: ciClientId
+  PUB_CLIENT_ORIGIN: http://localhost:5173
+  PUB_SENTRY_DSN: ""
+  PUB_FEATURE_FLAGS: load-save
+
+jobs:
+  # ── the Worker, gated at PR time with exactly what `deploy-server.yml` runs ──────────────
+  #
+  # Its own job rather than a step of `build-and-test` so the Worker has a distinct, fast
+  # signal, and so a merge can never produce a deploy that fails its own gate.
+  server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      # `npm ci`, never `npm install` — the committed lockfile is the only thing that makes
+      # this tree installable (see CLAUDE.md). It also fails outright if `package.json` and the
+      # lockfile have drifted apart, which is the lockfile-freshness check this repo needs and
+      # gets for free.
+      - name: Install
+        run: npm ci
+
+      # `check` is `tsc --noEmit` against the committed `worker-configuration.d.ts`. `build` is
+      # `wrangler deploy --dry-run`, which genuinely bundles the Worker and resolves every
+      # binding — so a KV/D1 id that no longer exists, or an idiom `nodejs_compat` rejects,
+      # fails here rather than on main. Through turbo so `core#build` runs first: the Worker's
+      # `import "core"` resolves into `core/dist`.
+      #
+      # Runs without a `server/.dev.vars` — same as the runner — which is exactly why
+      # `worker-configuration.d.ts` must stay committed. Regenerating it with `npm run
+      # cf-typegen` from a checkout that has no `.dev.vars` silently drops `FONTS_API_KEY` and
+      # friends from `Env` and breaks this step. See CLAUDE.md.
+      - name: Type check and bundle the Worker
+        run: npx turbo run check build --filter=server
+
+  # ── everything builds, and every unit test passes ────────────────────────────────────────
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # vite-imagetools transforms the image `+page.svelte` imports, which needs sharp's native
+      # binary — and sharp is not in the root `allowScripts`, so npm >= 11 skips the install
+      # script that fetches it. Same step, same reason, as the hermetic e2e job.
+      - name: Build sharp's native binary
+        run: npm rebuild sharp
+
+      # All four packages: the client bundle, the Worker dry-run, the plugin's `code.js` and
+      # `core/dist`. The client half is the new coverage — the e2e suite drives the *dev
+      # server*, so nothing on a PR has ever produced the bundle Pages deploys.
+      #
+      # `client#build`'s `postbuild` hook (the Sentry source-map upload) runs here too and is
+      # a no-op without `SENTRY_AUTH_TOKEN`: it logs `sentry: WARNING …` and exits 0 by design,
+      # since on Pages it sits in the deploy's critical path.
+      - name: Build every package
+        run: npx turbo run build
+
+      # client + core vitest, and the plugin's dependency-free node script — which runs the
+      # *built* `code.js` in a stubbed Figma sandbox, hence `plugin#test`'s `dependsOn: build`.
+      - name: Test every package
+        run: npx turbo run test
+
+      # An invariant, not a test, and the failure it guards is the whole site rather than one
+      # feature: nothing in the SSR graph may pull in a Sentry SDK. Every SDK that works on
+      # Cloudflare has a top-level `import { AsyncLocalStorage } from "node:async_hooks"`, and
+      # a *dynamic* import does not keep it out — adapter-cloudflare bundles `_worker.js` with
+      # esbuild, which hoists a lazily-reached module's external imports into static top-level
+      # ones. workerd only resolves `node:` specifiers with `nodejs_als`/`nodejs_compat`
+      # enabled, and the Pages project's flags live in the Cloudflare dashboard rather than in
+      # this repo — so a static import there risks the Worker failing to *start*.
+      #
+      # `client/src/services/sentryEnvelope.ts` is the hand-built envelope POST that exists to
+      # prevent exactly this, and CLAUDE.md documents this grep as the check on it. Exactly one
+      # match is expected: SvelteKit's own `import("node:async_hooks").then(…).catch(…)` probe,
+      # which is dynamic and harmless. Counted with `grep -o`, not `grep -c`, because
+      # `_worker.js` is bundled — `grep -c` counts *lines*, and two imports on one minified
+      # line would read as one.
+      - name: Assert no Sentry SDK reached the SSR bundle
+        run: |
+          worker=client/.svelte-kit/cloudflare/_worker.js
+          count=$(grep -o "node:async_hooks" "$worker" | wc -l | tr -d ' ')
+          if [ "$count" != "1" ]; then
+            echo "::error file=$worker::Expected exactly 1 'node:async_hooks' (SvelteKit's own dynamic probe), found $count. Something in the SSR graph now imports a Sentry SDK statically — see 'Error reporting' in CLAUDE.md."
+            exit 1
+          fi
+          echo "SSR bundle clean: 1 'node:async_hooks' (SvelteKit's dynamic probe)"
+
+      # `plugin/code.js` is committed because it *is* what Figma loads — it is the artefact, not
+      # a build product nobody reads. So it has to match `code.ts`, and nothing else would
+      # notice if it did not: a stale bundle means the reviewed source and the published plugin
+      # have quietly diverged. Reproducible because the plugin's release string is
+      # `plugin@<version>` from package.json, not a commit sha.
+      #
+      # `npx turbo run build` above already rebuilt it, so this only reads the result.
+      - name: Assert the committed plugin bundle matches its source
+        run: |
+          if ! git diff --quiet -- plugin/code.js; then
+            echo "::error file=plugin/code.js::plugin/code.js is out of date. Run 'npm run build --workspace plugin' and commit the result."
+            git diff --stat -- plugin/code.js
+            exit 1
+          fi
+          echo "plugin/code.js matches its source"
+
+  # ── type checking and linting, minus the two known-failing client tasks ──────────────────
+  static-analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # `!client` excludes `client#check` and `client#lint` only — `core`, `e2e`, `plugin` and
+      # `server` all pass today and are gated. Note `check` still builds `core` first (`^build`),
+      # since `svelte-check`/`tsc` resolve `core` through its `exports` map into `dist/`.
+      #
+      # Only `client` and `plugin` define `lint` at all, so in practice this is `plugin#lint`.
+      - name: Type check and lint
+        run: npx turbo run check lint --filter='!client'
+
+  # ── visibility only: cannot fail the workflow ────────────────────────────────────────────
+  #
+  # `client#check` and `client#lint` are known-failing on main and are not this workflow's to
+  # fix. Running them anyway means the numbers stay in the log, a PR that makes them worse is
+  # visible in review, and the day the eslint flat-config migration lands this job goes green
+  # and can be promoted into `static-analysis` by deleting the filter above.
+  known-failing:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # `|| true` per task so both run even when the first fails, and neither can fail the
+      # step. `continue-on-error` on the job is the belt to this braces: without the `|| true`
+      # turbo would stop at `check` and never report `lint`.
+      - name: Client type check (informational)
+        run: npx turbo run check --filter=client || true
+
+      - name: Client lint (informational)
+        run: npx turbo run lint --filter=client || true

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -120,21 +120,39 @@ jobs:
 
       # A deployed Worker that does not answer is the failure mode this catches: the bundle
       # uploaded fine and something at the edge — a binding, a secret read at module init —
-      # kills it on the first request. `/api/fonts` is the one unauthenticated GET, and it is
-      # handled before Express, so a 200 proves both the runtime and the KV binding.
+      # kills it on the first request.
+      #
+      # Two probes, because they prove different things and only one of them can be trusted:
+      #
+      # `/api/__liveness` is any unmatched path, answered by Express's own 404 handler. It
+      # carries no `cf-cache-status` header at all, so it is never served from cache and
+      # reaches the Worker on every request — which makes Express's 404 body the one thing
+      # here that actually proves the freshly uploaded bundle booted. This is the gate.
+      #
+      # `/api/fonts` is the only probe that would exercise the KV binding, but it cannot gate
+      # anything: `snapshot.ts` serves it `public, max-age=3600, s-maxage=86400` and the cache
+      # key ignores the query string (verified — `?cb=…` still answers `cf-cache-status: HIT`),
+      # so it keeps returning 200 for up to 24 hours after the Worker has stopped working.
+      # Reported for the log, never asserted on.
       - name: Smoke test the deployment
+        env:
+          API: https://api.typescalegarden.uy
         run: |
           for attempt in 1 2 3; do
-            # `|| true` so a connection failure is an empty $code and another attempt, rather
+            # `|| true` so a connection failure is an empty $body and another attempt, rather
             # than the job's default `bash -e` aborting the loop on the first one.
-            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-              "https://api.typescalegarden.uy/api/fonts" || true)
-            if [ "$code" = "200" ]; then
-              echo "GET /api/fonts → 200"
-              exit 0
-            fi
-            echo "attempt $attempt: GET /api/fonts → ${code:-no response}"
+            body=$(curl -sS --max-time 30 "$API/api/__liveness" || true)
+            case "$body" in
+              *'"message":"Not Found"'*)
+                echo "GET /api/__liveness → Express 404, the Worker is serving"
+                code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                  "$API/api/fonts" || true)
+                echo "GET /api/fonts → ${code:-no response} (edge-cached, advisory only)"
+                exit 0
+                ;;
+            esac
+            echo "attempt $attempt: /api/__liveness → ${body:-no response}"
             sleep 10
           done
-          echo "::error::The deployed Worker did not answer GET /api/fonts with a 200."
+          echo "::error::The deployed Worker never answered /api/__liveness with Express's 404 — it is not serving."
           exit 1

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,0 +1,140 @@
+# Deploys the Worker (`server/`) to Cloudflare when server code lands on main.
+#
+# Replaces running `npm run deploy:server` from a laptop, which is how `api.typescalegarden.uy`
+# shipped until now — the client has had continuous deployment since it moved to Pages, and the
+# Worker was the only half still deployed by hand.
+#
+# Its own workflow rather than a job in `e2e.yml` for the same reason that one is separate: the
+# triggers do not overlap (that suite runs on every PR, this only on main), and `client#check` /
+# `client#lint` are known-failing on main, so anything sharing a workflow with them inherits a
+# permanently red signal. The gate here is `server#check` + `server#build`, both of which pass.
+name: deploy-server
+
+on:
+  push:
+    branches: [main]
+    # Only when something that ends up inside the Worker bundle changed. `core/**` is in the
+    # list because `src/db/`, the fonts snapshot and the plugin routes all import it, so a
+    # scale-math change ships in this bundle as much as in the client's. The root manifests are
+    # here because a dependency bump changes what gets bundled without touching `server/`.
+    paths:
+      - "server/**"
+      - "core/**"
+      - "types/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "turbo.json"
+      - ".node-version"
+      - ".github/workflows/deploy-server.yml"
+  # For redeploying the current main without an empty commit — a reverted secret, a Cloudflare
+  # incident, a migration applied out of band.
+  workflow_dispatch:
+
+# Never cancel a deploy in flight. Migrations are applied before the upload and are
+# forward-only, so a half-run deploy is worse than a queued one; runs are serialised instead.
+concurrency:
+  group: deploy-server
+  cancel-in-progress: false
+
+# Nothing here writes to the repo — the credential that matters is the Cloudflare token, not
+# GITHUB_TOKEN. Narrowed explicitly so a permissive repo default does not hand a deploy job
+# write access it has no use for.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Names the deploy in GitHub's Environments UI, and is where a required-reviewer gate would
+    # go if this ever needs one.
+    environment:
+      name: worker-production
+      url: https://api.typescalegarden.uy
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      # `npm ci`, never `npm install`: the committed lockfile is the only thing that makes this
+      # tree installable at all — a fresh resolve hits ERESOLVE on two of the client's stale
+      # peer ranges. See CLAUDE.md. No `npm rebuild sharp` here, unlike the hermetic e2e job:
+      # nothing in this workflow compiles the client.
+      - name: Install
+        run: npm ci
+
+      # Fail here rather than 30 seconds later inside wrangler, where a missing token surfaces
+      # as an attempt to open an OAuth browser flow on a headless runner.
+      - name: Check the Cloudflare credentials are present
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          missing=
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN"
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing="$missing CLOUDFLARE_ACCOUNT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secret(s):$missing — set them in Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      # The gate, and it is a real one. `check` is `tsc --noEmit` against the committed
+      # `worker-configuration.d.ts`; `build` is `wrangler deploy --dry-run`, which bundles the
+      # Worker and resolves every binding, so a KV/D1 id that no longer exists or a
+      # `nodejs_compat` violation fails before anything is applied to production. Through turbo
+      # so `core#build` runs first — `server`'s `import "core"` resolves into `core/dist`.
+      - name: Type check and bundle
+        run: npx turbo run check build --filter=server
+
+      # Before the upload, not after: new code that reads a column the production database does
+      # not have yet would 500 for the length of the gap. Idempotent — D1 tracks what it has
+      # applied, so a deploy with no new migration prints "No migrations to apply" and moves on.
+      # Wrangler skips its confirmation prompt when it detects CI.
+      #
+      # Forward-only, and there is no automated rollback: a migration that lands wrong has to be
+      # corrected by a follow-up migration. Review `server/migrations/` accordingly.
+      - name: Apply pending D1 migrations
+        working-directory: server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run db:migrate:remote
+
+      # `wrangler deploy` directly rather than the root `deploy:server`, whose turbo task
+      # depends on `build` — i.e. a second `--dry-run` bundle — and which would run before the
+      # migrations above rather than after them.
+      #
+      # Secrets are NOT deployed here. `wrangler secret put` state lives on Cloudflare and
+      # survives a deploy; keeping them out means this workflow needs no copy of them.
+      - name: Deploy
+        working-directory: server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run deploy
+
+      # A deployed Worker that does not answer is the failure mode this catches: the bundle
+      # uploaded fine and something at the edge — a binding, a secret read at module init —
+      # kills it on the first request. `/api/fonts` is the one unauthenticated GET, and it is
+      # handled before Express, so a 200 proves both the runtime and the KV binding.
+      - name: Smoke test the deployment
+        run: |
+          for attempt in 1 2 3; do
+            # `|| true` so a connection failure is an empty $code and another attempt, rather
+            # than the job's default `bash -e` aborting the loop on the first one.
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+              "https://api.typescalegarden.uy/api/fonts" || true)
+            if [ "$code" = "200" ]; then
+              echo "GET /api/fonts → 200"
+              exit 0
+            fi
+            echo "attempt $attempt: GET /api/fonts → ${code:-no response}"
+            sleep 10
+          done
+          echo "::error::The deployed Worker did not answer GET /api/fonts with a 200."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,32 @@ Switching the Pages build command to `npx turbo run build --filter=client` would
 unnecessary (it works from `client/`, and builds `core` first through the task graph) and would give
 the deploy turbo's cache. The committed setup avoids depending on a dashboard change.
 
+### Deploying the Worker
+
+`.github/workflows/deploy-server.yml` does it, on a push to main that touches the Worker bundle.
+`npm run deploy:server` from a laptop still works and is what a hotfix should use, but it is no
+longer the normal path. The job type checks, bundles (`wrangler deploy --dry-run`, which resolves
+every binding), applies pending D1 migrations, deploys, and then smoke tests `GET /api/fonts` — the
+one unauthenticated GET, answered before Express, so a 200 proves both the runtime and the KV
+binding came up.
+
+- **Its path filter covers `core` too**, not only `server`: `src/db/`, the fonts snapshot and the
+  plugin routes all import `core`, so a scale-math change ships in this bundle as much as in the
+  client's. The root manifests are in the filter for the same class of reason — a dependency bump
+  changes the bundle without touching `server/`.
+- **Migrations run before the upload,** so new code cannot outrun its schema. They are
+  forward-only and there is no automated rollback — a bad one is corrected by the next migration.
+  Wrangler's confirmation prompt auto-answers yes in CI, and an empty queue is a no-op.
+- **Two repository secrets are required**, `CLOUDFLARE_API_TOKEN` (Workers Scripts / D1 / KV: Edit)
+  and `CLOUDFLARE_ACCOUNT_ID` — `wrangler.jsonc` carries no `account_id`, and a token with access
+  to more than one account cannot infer it. A step checks for both up front, because a missing
+  token otherwise surfaces as wrangler trying to open an OAuth browser flow on a headless runner.
+- **Worker secrets are not deployed by CI.** `wrangler secret put` state lives on Cloudflare and
+  survives a deploy, so the workflow needs no copy of `JWT_SECRET`, `SESSION_SECRET` or
+  `FONTS_API_KEY`.
+- **`concurrency` does not cancel in flight** (unlike `e2e.yml`): a deploy interrupted between the
+  migration and the upload is worse than a queued one, so runs serialise.
+
 From the repo root — these fan out through turbo to every package that defines the script:
 
 ```bash
@@ -280,7 +306,8 @@ Things worth knowing before changing it:
 
 #### CI
 
-`.github/workflows/e2e.yml` — the repo's only workflow — runs the one suite three ways:
+`.github/workflows/e2e.yml` — one of the repo's two workflows, the other being `deploy-server.yml`
+(see "Deploying the Worker" below) — runs the one suite three ways:
 
 | job        | trigger                             | `E2E_TARGET`               |
 | ---------- | ----------------------------------- | -------------------------- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,17 @@ client's dev server itself (`webServer.command`), bypassing turbo, so nothing el
 `core/dist` that the client's `import "core"` resolves into. `client#build` would be the wrong
 dependency: the suite drives the dev server, not the bundle.
 
+**`e2e#check` needs the same edge, and for a subtler reason.** `e2e` declares no dependency on
+`core` in its `package.json` — `support/subjects.ts` reaches it by _relative path_
+(`../../core/dist/index.js`), because `core` is `"type": "module"` and these files transpile to
+CommonJS. So the root `check` task's `dependsOn: ["^build"]` resolves to **nothing** here, and the
+task was simply unordered against `core#build`. It passed on any developer's machine, where `dist/`
+was already on disk from an earlier build, and failed on a clean checkout with
+`TS2307: Cannot find module '../../core/dist/index.js'` — which is exactly what CI found the first
+time it ran. `e2e/turbo.json` now declares `check` with `dependsOn: ["core#build"]` too. The edge
+also puts `core#build`'s hash in the task's cache key, so a stale pass cannot be replayed after
+core changes.
+
 Known pre-existing failures, unrelated to turbo: `client#check` (17 svelte-check errors) and
 `client#lint` (the client's `.eslintrc.cjs` fails to load, plus wide prettier drift). `client#test`
 used to fail on 3 letterSpacing assertions; rewiring the client onto `core` fixed those, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,7 @@ the deploy turbo's cache. The committed setup avoids depending on a dashboard ch
 `.github/workflows/deploy-server.yml` does it, on a push to main that touches the Worker bundle.
 `npm run deploy:server` from a laptop still works and is what a hotfix should use, but it is no
 longer the normal path. The job type checks, bundles (`wrangler deploy --dry-run`, which resolves
-every binding), applies pending D1 migrations, deploys, and then smoke tests `GET /api/fonts` — the
-one unauthenticated GET, answered before Express, so a 200 proves both the runtime and the KV
-binding came up.
+every binding), applies pending D1 migrations, deploys, and then smoke tests the result.
 
 - **Its path filter covers `core` too**, not only `server`: `src/db/`, the fonts snapshot and the
   plugin routes all import `core`, so a scale-math change ships in this bundle as much as in the
@@ -128,6 +126,13 @@ binding came up.
   `FONTS_API_KEY`.
 - **`concurrency` does not cancel in flight** (unlike `e2e.yml`): a deploy interrupted between the
   migration and the upload is worse than a queued one, so runs serialise.
+- **The smoke test gates on `/api/__liveness`, not on `/api/fonts`,** and this is the non-obvious
+  part. `/api/fonts` looks like the ideal probe — one unauthenticated GET, answered before Express,
+  exercising the KV binding — but it is edge-cached at `s-maxage=86400` and **the cache key ignores
+  the query string**, so no cache-buster reaches the origin and it keeps answering 200 for a day
+  after the Worker has died. Any unmatched path (`/api/__liveness`) is answered by Express's 404
+  handler with no `cf-cache-status` at all, so it hits the fresh bundle every time; that 404 body
+  is the assertion. `/api/fonts` is still probed, but only logged.
 
 From the repo root — these fan out through turbo to every package that defines the script:
 
@@ -306,8 +311,10 @@ Things worth knowing before changing it:
 
 #### CI
 
-`.github/workflows/e2e.yml` — one of the repo's two workflows, the other being `deploy-server.yml`
-(see "Deploying the Worker" below) — runs the one suite three ways:
+There are three workflows: `e2e.yml` (this section), `ci.yml` (everything non-browser — see "The
+rest of CI" below) and `deploy-server.yml` (see "Deploying the Worker" above).
+
+`.github/workflows/e2e.yml` runs the one suite three ways:
 
 | job        | trigger                             | `E2E_TARGET`               |
 | ---------- | ----------------------------------- | -------------------------- |
@@ -329,6 +336,41 @@ make the signal permanently red. Non-obvious details:
   signed-in and write specs skip with a reason and the rest still runs anonymously, which is a useful
   signal on its own. `E2E_LIVE_WRITES` is a repository variable, so writes can be turned off without
   touching code. GitHub disables scheduled workflows after 60 days of repo inactivity.
+
+#### The rest of CI
+
+`.github/workflows/ci.yml` is the non-browser PR gate, on `pull_request` and `push` to main. Before
+it, the hermetic Playwright suite was the repo's only check — so nothing type checked the Worker,
+nothing ever built the client **bundle** (the suite drives the dev server), and no unit test ran. A
+broken `server/` reached main and was caught only by `deploy-server.yml`, after it had deployed; a
+broken client bundle was caught by Pages, also after merge.
+
+| job               | gates                                                       |
+| ----------------- | ----------------------------------------------------------- |
+| `server`          | `turbo run check build --filter=server` — the deploy's gate |
+| `build-and-test`  | `turbo run build`, `turbo run test`, plus two invariants    |
+| `static-analysis` | `turbo run check lint --filter='!client'`                   |
+| `known-failing`   | `client#check` / `client#lint` — `continue-on-error`        |
+
+- **The workflow defines the `PUB_*` vars itself**, at workflow level, and without them neither
+  `client#build` nor `client#test` can pass — `$env/static/public` is a virtual module built from
+  what is defined, so a name the client imports and CI does not define is a build error. Throwaway
+  values: CI never deploys its bundle, Pages builds its own with the dashboard's values. Keep them
+  in step with `E2E_PUB_ENV` in `e2e/support/env.ts`, which is the same list for the same reason.
+- **`server` is its own job** rather than a step of `build-and-test`, running exactly what
+  `deploy-server.yml` runs as its gate — so a merge cannot produce a deploy that fails its own gate.
+- **Two invariants are asserted that no test covers.** The `node:async_hooks` grep over
+  `client/.svelte-kit/cloudflare/_worker.js` (see "Error reporting" — expects exactly 1, SvelteKit's
+  own dynamic probe; counted with `grep -o` and not `grep -c`, since `_worker.js` is bundled and
+  `grep -c` counts lines); and `git diff --quiet -- plugin/code.js` after a rebuild, since that file
+  is committed because it **is** what Figma loads, and a stale one means the reviewed source and the
+  published plugin have diverged. The plugin bundle is reproducible because its release string is
+  `plugin@<version>`, not a commit sha.
+- **`known-failing` cannot fail the workflow.** It exists so the two known-failing client tasks stay
+  visible and a PR that makes them worse shows up in review. When the eslint flat-config migration
+  lands it goes green, and gets promoted by deleting `--filter='!client'` in `static-analysis`.
+- `npm ci` doubles as the lockfile-freshness check: it fails outright if `package.json` and
+  `package-lock.json` have drifted apart.
 
 #### Pointing a live run at a preview deployment
 
@@ -353,7 +395,21 @@ Root `turbo.json` declares the task shapes: `build`/`check`/`test` depend on `^b
 dependencies build first), `dev` and `test:watch` are `persistent` + uncached, `deploy` depends on
 `build` and `check`. Cache keys include the root `tsconfig.json`, `types/**` and the root `.env*`
 files (`globalDependencies`) plus every `PUB_*` var, since those are inlined into the client bundle at
-build time. Cacheable outputs are declared per package in `client/turbo.json`, `core/turbo.json` and
+build time.
+
+**`build`, `check` and `test` all declare `"env": ["PUB_*"]`, and on the latter two that is not
+about caching.** Turbo filters a task's environment down to what it declares, so a task missing the
+declaration cannot see those vars _at all_, whatever the developer's `.env` holds:
+
+- `test` without it — `stores/config.test.ts` fails to collect. It imports `errorLogger` →
+  `sentry` → `services/env.ts`, which throws `There was an issue loading env variables` when
+  `PUB_API_URL` is falsy. `npm test --workspace client` passes at the same moment, which is what
+  makes this look like a turbo bug rather than a missing line.
+- `check` without it — `svelte-kit sync` generates the `$env/static/public` ambient types from
+  whatever is defined, so svelte-check reports six phantom `has no exported member 'PUB_…'`
+  errors on top of the real ones.
+
+Cacheable outputs are declared per package in `client/turbo.json`, `core/turbo.json` and
 `plugin/turbo.json`; the server emits nothing (its build is a dry-run), so it needs no override. The
 `db:*` scripts are deliberately outside turbo — they mutate a real database and must never be cached.
 
@@ -364,10 +420,15 @@ client's dev server itself (`webServer.command`), bypassing turbo, so nothing el
 `core/dist` that the client's `import "core"` resolves into. `client#build` would be the wrong
 dependency: the suite drives the dev server, not the bundle.
 
-Known pre-existing failures, unrelated to turbo: `client#check` (18 svelte-check errors) and
+Known pre-existing failures, unrelated to turbo: `client#check` (17 svelte-check errors) and
 `client#lint` (the client's `.eslintrc.cjs` fails to load, plus wide prettier drift). `client#test`
 used to fail on 3 letterSpacing assertions; rewiring the client onto `core` fixed those, and
-`build` and `test` are now green across every package.
+`build` and `test` are now green across every package. Both known failures run in `ci.yml`'s
+`known-failing` job, which cannot fail the workflow — see "CI" below.
+
+Note the 17: it used to be quoted as 18 because the count was taken without `PUB_*` reaching
+svelte-check. With the `env` declaration above, the six phantom `$env/static/public` errors are
+gone and 17 is the real number.
 
 ## Architecture
 

--- a/e2e/turbo.json
+++ b/e2e/turbo.json
@@ -2,6 +2,20 @@
 	"$schema": "https://turborepo.com/schema.json",
 	"extends": ["//"],
 	"tasks": {
+		// `tsc --noEmit` over these files, and it needs `core/dist` on disk for the same
+		// reason `test:e2e` does: `support/subjects.ts` reaches core by *relative path*
+		// (`../../core/dist/index.js`), not through the package name, so `e2e` declares no
+		// dependency on `core` in its package.json and the root task's `dependsOn:
+		// ["^build"]` therefore resolves to nothing here.
+		//
+		// Without this the task is simply unordered against `core#build` and fails on a
+		// clean checkout with `TS2307: Cannot find module '../../core/dist/index.js'` — it
+		// only ever passed because a developer's tree already had `dist/` from some earlier
+		// build. It also makes `core#build`'s hash part of this task's cache key, so a
+		// stale pass cannot be replayed after core changes.
+		"check": {
+			"dependsOn": ["core#build"]
+		},
 		"test:e2e": {
 			// `core#build`, not `^build`: Playwright boots the client's dev server itself
 			// (`webServer.command`), which bypasses turbo — so nothing else would build

--- a/todos/auto-deploy-server.md
+++ b/todos/auto-deploy-server.md
@@ -5,3 +5,40 @@ CI auto deploy on server
 ## Description
 
 Auto deploy BE to CF worker when server code is merged to main
+
+## Status — done
+
+`.github/workflows/deploy-server.yml`. A push to main that touches anything ending up in the Worker
+bundle type checks it, bundles it, applies pending D1 migrations and runs `wrangler deploy`, then
+smoke tests the result. `workflow_dispatch` redeploys the current main without an empty commit.
+
+| step       | command                                     | why                                              |
+| ---------- | ------------------------------------------- | ------------------------------------------------ |
+| gate       | `npx turbo run check build --filter=server` | `tsc --noEmit` + `wrangler deploy --dry-run`     |
+| migrations | `npm run db:migrate:remote` in `server/`    | before the upload, so no code outruns its schema |
+| deploy     | `npm run deploy` in `server/`               | `wrangler deploy`                                |
+| smoke test | `GET /api/fonts`, 3 attempts                | proves the deployed Worker actually answers      |
+
+Paths watched: `server/**`, `core/**` (the Worker bundles it), `types/**`, and the root manifests —
+a dependency bump changes the bundle without touching `server/`.
+
+### Setup still required on the repo
+
+Two **repository secrets**, without which the first run fails at the credentials check with a named
+error rather than hanging on wrangler's OAuth flow:
+
+- `CLOUDFLARE_API_TOKEN` — needs Workers Scripts: Edit, D1: Edit, and Workers KV Storage: Edit.
+- `CLOUDFLARE_ACCOUNT_ID` — `wrangler.jsonc` carries no `account_id`, and inference is ambiguous
+  when a token can see more than one account.
+
+The job declares `environment: worker-production`; creating that environment in Settings is optional
+(it is auto-created on first use) but is where a required-reviewer gate would go.
+
+### Deliberately not done
+
+- **Secrets are not deployed.** `JWT_SECRET`, `SESSION_SECRET` and `FONTS_API_KEY` live on
+  Cloudflare via `wrangler secret put` and survive a deploy, so CI needs no copy of them.
+- **No rollback.** D1 migrations are forward-only and `wrangler rollback` is a separate manual
+  decision; a bad migration is corrected by the next one.
+- **Not folded into `e2e.yml`.** Different triggers, and that workflow's jobs deliberately exclude
+  `client#check` / `client#lint` for being known-failing on main.

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,11 @@
 		// Type checking. Emits nothing, but is still cacheable on its inputs.
 		"check": {
 			"dependsOn": ["^build"],
+			// `svelte-kit sync` generates the ambient types for `$env/static/public` from
+			// whatever `PUB_*` names are defined, so without this turbo filters them out and
+			// svelte-check reports six phantom "has no exported member 'PUB_…'" errors on top
+			// of the real ones. Same declaration, same reason, as `build` and `test`.
+			"env": ["PUB_*"],
 			"outputs": []
 		},
 		"lint": {
@@ -27,6 +32,14 @@
 		},
 		"test": {
 			"dependsOn": ["^build"],
+			// Same `PUB_*` declaration as `build`, and for a stronger reason than caching.
+			// Turbo filters a task's environment down to what it declares, so without this
+			// the client's vitest run sees no `PUB_API_URL` at all — `services/env.ts`
+			// throws "There was an issue loading env variables" on import and
+			// `stores/config.test.ts` fails to collect, whatever the developer's `.env`
+			// says. `npm test --workspace client` passes at the same moment, which is what
+			// makes it look like a turbo bug rather than a missing declaration.
+			"env": ["PUB_*"],
 			"outputs": []
 		},
 		// Browser tests. Never cached: they boot a real dev server and drive a real


### PR DESCRIPTION
Two related pieces of CI. Closes `todos/auto-deploy-server.md`.

1. **`ci.yml`** — a PR gate for everything the browser suite does not cover.
2. **`deploy-server.yml`** — the Worker deploys itself on merge to main.

They connect: `ci.yml`'s `server` job runs exactly what `deploy-server.yml` runs as its gate, so a merge cannot produce a deploy that fails its own gate.

---

## 1. `ci.yml` — the non-browser PR gate

The hermetic Playwright suite was the repo's only check, and it drives the client's **dev server**. So nothing on a PR type checked the Worker, nothing ever produced the client bundle Pages deploys, and no unit test ran. A broken `server/` reached main and was caught only after it had deployed; a broken client bundle was caught by Pages, also after merge.

| job | gates |
| --- | --- |
| `server` | `turbo run check build --filter=server` — the deploy's own gate, at PR time |
| `build-and-test` | `turbo run build` + `turbo run test` across all four packages, plus two invariants |
| `static-analysis` | `turbo run check lint --filter='!client'` |
| `known-failing` | `client#check` / `client#lint`, `continue-on-error` |

**Two invariants nothing else covers:**

- **`node:async_hooks` count in the SSR bundle.** CLAUDE.md documents this grep as the check on `services/sentryEnvelope.ts`; its failure mode is the Worker not *starting*, i.e. the whole site. Expects exactly 1 — SvelteKit's own dynamic probe. Counted with `grep -o`, not `grep -c`, because `_worker.js` is bundled and `grep -c` counts lines.
- **`plugin/code.js` matches its source.** It is committed because it *is* what Figma loads, so a stale bundle means the reviewed source and the published plugin have diverged. Reproducible because the plugin's release string is `plugin@<version>`, not a commit sha.

**`known-failing` cannot fail the workflow.** `client#check` (17 svelte-check errors) and `client#lint` (`.eslintrc.cjs` cannot load under eslint 10) are long-standing and orthogonal to any given PR — gating on them would make this permanently red, the same reasoning that keeps them out of `e2e.yml`. Running them anyway keeps the drift visible; when the flat-config migration lands the job goes green and gets promoted by deleting one filter.

## A turbo misconfiguration found along the way

`check` and `test` did not declare `"env": ["PUB_*"]`. Turbo filters a task's environment down to what it declares, so those vars did not reach the tasks **at all**, whatever the developer's `.env` held:

- **`client#test` failed on collection.** `stores/config.test.ts` imports `errorLogger` → `sentry` → `services/env.ts`, which throws `There was an issue loading env variables` when `PUB_API_URL` is falsy. `npm test --workspace client` passed at the same moment — which is exactly what made it look like a turbo bug rather than a missing line.
- **`client#check` reported six phantom** `has no exported member 'PUB_…'` errors, because `svelte-kit sync` generates the `$env/static/public` ambient types from what is defined. The real error count is **17**, not the 18 quoted until now.

This is a cache-correctness fix as much as a functional one: both tasks genuinely depend on `PUB_*` and neither had it in its key.

## Verification

Every assertion in the workflow was run locally from a cleared turbo cache, in a worktree with **no `.env`** and **no `.dev.vars`** — what a runner sees:

| command | result |
| --- | --- |
| `turbo run check build --filter=server` | 3/3 |
| `turbo run build` | 4/4 |
| `turbo run test` | 5/5 |
| `turbo run check lint --filter='!client'` | 6/6 |
| `node:async_hooks` invariant | 1, as expected |
| `plugin/code.js` drift | clean |

Before the turbo fix, `turbo run test` was 4/5 and `turbo run build` 3/4.

---

## 2. `deploy-server.yml` — auto deploy on merge

`api.typescalegarden.uy` was the only half of the project still deployed by hand.

| step | command | why |
| --- | --- | --- |
| gate | `turbo run check build --filter=server` | `tsc --noEmit` + `wrangler deploy --dry-run` |
| migrations | `npm run db:migrate:remote` | before the upload, so no code outruns its schema |
| deploy | `npm run deploy` | `wrangler deploy` |
| smoke test | `GET /api/__liveness` | proves the fresh bundle booted |

- **The smoke test gates on `/api/__liveness`, not `/api/fonts`.** `/api/fonts` looks ideal — one unauthenticated GET exercising the KV binding — but it is edge-cached at `s-maxage=86400` and the cache key ignores the query string, so no cache-buster reaches the origin and it keeps answering 200 for a day after the Worker has died. Any unmatched path is answered by Express's 404 handler with no `cf-cache-status` at all. `/api/fonts` is still probed, but only logged.
- **The path filter covers `core/**`** — the Worker bundles it.
- **Migrations run before the upload.** Idempotent; forward-only, no automated rollback.
- **`cancel-in-progress: false`** — a deploy interrupted between the migration and the upload is worse than a queued one.
- **Worker secrets are not deployed.** `wrangler secret put` state lives on Cloudflare and survives a deploy.

### ⚠️ Two repository secrets required before merging

- **`CLOUDFLARE_API_TOKEN`** — custom token with **Workers Scripts: Edit**, **D1: Edit**, **Workers KV Storage: Edit**, **Account Settings: Read**, account-scoped to the one account. These cannot be zone-scoped: Workers/D1/KV are account-level in Cloudflare's model.
- **`CLOUDFLARE_ACCOUNT_ID`**

A guard step fails with a named error if either is missing, rather than letting wrangler hang on an OAuth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)