### PR TITLE
ci: stop reporting Cloudflare's bot challenge as a failing live e2e run

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -139,19 +139,43 @@ jobs:
           API: https://api.typescalegarden.uy
         run: |
           for attempt in 1 2 3; do
-            # `|| true` so a connection failure is an empty $body and another attempt, rather
-            # than the job's default `bash -e` aborting the loop on the first one.
-            body=$(curl -sS --max-time 30 "$API/api/__liveness" || true)
-            case "$body" in
-              *'"message":"Not Found"'*)
-                echo "GET /api/__liveness → Express 404, the Worker is serving"
-                code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-                  "$API/api/fonts" || true)
-                echo "GET /api/fonts → ${code:-no response} (edge-cached, advisory only)"
-                exit 0
-                ;;
-            esac
-            echo "attempt $attempt: /api/__liveness → ${body:-no response}"
+            # Headers and body kept separately: the verdict below needs both, and `|| true`
+            # keeps a connection failure to another attempt rather than aborting the loop on
+            # the job's default `bash -e`.
+            code=$(curl -sS -o /tmp/smoke.body -D /tmp/smoke.head -w '%{http_code}' \
+              --max-time 30 "$API/api/__liveness" || true)
+
+            # Cloudflare challenging this runner's datacenter IP, which is what a
+            # GitHub-hosted runner has. Checked before anything else because it is answered at
+            # the edge — the Worker is never reached, so the response proves nothing either
+            # way, and no redeploy can change it. Reporting it as "the Worker is not serving"
+            # is what this step used to do, and it is precisely wrong: the deploy succeeded,
+            # and wrangler already confirmed the upload in the step above.
+            #
+            # Passing rather than failing is a deliberate trade. It does mean a genuinely
+            # broken Worker goes unreported while the challenge is in place — but the probe
+            # cannot run either way, so the only thing failing would buy is a red mark on
+            # every deploy for a reason nobody can fix from this repo. CLAUDE.md records the
+            # Cloudflare-side change that restores the check.
+            if grep -qi '^cf-mitigated:' /tmp/smoke.head 2>/dev/null; then
+              echo "::warning title=Smoke test skipped::Cloudflare is challenging this runner, so the deployment could not be probed from CI. The upload itself succeeded."
+              echo "GET /api/__liveness → $code, behind a Cloudflare challenge:"
+              grep -i '^cf-mitigated:' /tmp/smoke.head
+              echo "The Worker was never reached, so this says nothing about the deploy."
+              exit 0
+            fi
+
+            if grep -q '"message":"Not Found"' /tmp/smoke.body 2>/dev/null; then
+              echo "GET /api/__liveness → Express 404, the Worker is serving"
+              fonts=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                "$API/api/fonts" || true)
+              echo "GET /api/fonts → ${fonts:-no response} (edge-cached, advisory only)"
+              exit 0
+            fi
+
+            # Truncated on purpose: an unexpected answer is usually an HTML error page, and
+            # three full copies of one buries the actual outcome under 15 kB of markup.
+            echo "attempt $attempt: /api/__liveness → ${code:-no response} $(head -c 200 /tmp/smoke.body 2>/dev/null)"
             sleep 10
           done
           echo "::error::The deployed Worker never answered /api/__liveness with Express's 404 — it is not serving."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,19 +117,92 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
-  # ── the live runs: a deployed build, the real API, a real Auth0 user ────────────────────
+  # ── can a runner reach production at all? ───────────────────────────────────────────────
   #
-  # Same suite. What it cannot assert live — a controlled tenant, a forced API failure, the
-  # synthetic font shapes — is skipped with a stated reason, so the run reports its own
-  # coverage gap. What it uniquely proves is that the deployed build, CORS, auth and the
-  # catalogue endpoint all still agree with `core`.
-  live:
+  # Both `typescalegarden.uy` and `api.typescalegarden.uy` sit behind Cloudflare, whose bot
+  # mitigation challenges requests from datacenter IP ranges — which is precisely what a
+  # GitHub-hosted runner has. The challenge is answered at Cloudflare's edge, so it says
+  # nothing about the deployment, and it blocks every client the suite could possibly use:
+  # node's fetch, Playwright's request context, an in-page `fetch` (the challenge carries no
+  # CORS headers, so it surfaces as `TypeError: Failed to fetch`) and even a real Chromium
+  # navigation, which lands on a Turnstile page a headless browser does not clear.
+  # e2e/support/challenge.ts records the measurements.
+  #
+  # So this is probed rather than discovered: without it the hourly cron reports a 403 as
+  # though production had regressed, which is what it did for every run between the live job
+  # landing and this. A challenged run now ends as a skip with a stated reason — the same way
+  # the suite already treats missing credentials and a full account — instead of as a failure
+  # nobody can act on from inside this repo.
+  #
+  # It runs first and checks nothing out, so a blocked run costs seconds rather than a full
+  # `npm ci` plus a browser download. And it self-heals: the moment the Cloudflare-side rule
+  # in CLAUDE.md is in place, the probe passes and `live` runs again with no change here.
+  live-reachable:
     if: |
       github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'deployment_status'
           && github.event.deployment_status.state == 'success'
           && github.event.deployment.environment == 'production')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      blocked: ${{ steps.probe.outputs.blocked }}
+
+    steps:
+      - name: Probe the API for a Cloudflare challenge
+        id: probe
+        env:
+          # The API every live target resolves to today — `E2E_API_URL` aside, this is the
+          # default `e2e/support/target.ts` applies to `prod` and to a bare URL target alike,
+          # and the same constant deploy-server.yml's smoke test carries.
+          API: https://api.typescalegarden.uy
+        run: |
+          # Headers only: the catalogue is ~1.9 MB and the verdict is one header. `|| true`
+          # keeps a connection failure from aborting the step under `bash -e` — that is not a
+          # challenge, and it should fall through to the suite, which reports it properly.
+          headers=$(curl -sS -o /dev/null -D - --max-time 30 "$API/api/fonts" || true)
+
+          # `cf-mitigated` is set on every response Cloudflare mitigates and on nothing this
+          # repo serves, so its mere presence is the signal.
+          mitigated=$(printf '%s' "$headers" | grep -i '^cf-mitigated:' || true)
+
+          if [ -z "$mitigated" ]; then
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            echo "No challenge — this runner can reach $API, so the live suite will run."
+            exit 0
+          fi
+
+          echo "blocked=true" >> "$GITHUB_OUTPUT"
+          echo "::warning title=Live e2e skipped::Cloudflare is challenging this runner, so the live suite cannot reach production. Not a deployment failure — see the job log and CLAUDE.md."
+          cat <<'EOF'
+          Cloudflare is challenging this runner, so the live suite was skipped.
+
+          What this is NOT: a broken deployment. The challenge is answered at Cloudflare's
+          edge and the Worker never sees the request, so production is serving real visitors
+          normally. `server/src/` contains no 403 at all.
+
+          What it IS: bot mitigation reacting to a GitHub-hosted runner's datacenter IP. It
+          blocks every client the suite could use, so there is no workaround inside this repo
+          short of faking the API — which would defeat the entire point of a live run.
+
+          To turn this back on, exempt CI at the Cloudflare edge. CLAUDE.md, under "Why the
+          live e2e run cannot reach production from CI", records the options.
+          EOF
+          printf 'observed: %s\n' "$mitigated"
+
+  # ── the live runs: a deployed build, the real API, a real Auth0 user ────────────────────
+  #
+  # Same suite. What it cannot assert live — a controlled tenant, a forced API failure, the
+  # synthetic font shapes — is skipped with a stated reason, so the run reports its own
+  # coverage gap. What it uniquely proves is that the deployed build, CORS, auth and the
+  # catalogue endpoint all still agree with `core`.
+  #
+  # The event filter lives on `live-reachable` above; a skipped dependency skips this too, so
+  # the only condition needed here is the probe's verdict.
+  live:
+    needs: live-reachable
+    if: needs.live-reachable.outputs.blocked == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,9 @@ rest of CI" below) and `deploy-server.yml` (see "Deploying the Worker" above).
 | `live`     | `deployment_status` (prod, success) | the URL that just deployed |
 | `live`     | `schedule`, hourly at `:17`         | `prod`                     |
 
+`live` is gated behind a `live-reachable` probe job — see "Why the live e2e run cannot reach
+production from CI" below, which is currently why it never actually runs.
+
 It deliberately does not also run `check`/`lint`, which are known-failing on main (below) and would
 make the signal permanently red. Non-obvious details:
 
@@ -336,6 +339,65 @@ make the signal permanently red. Non-obvious details:
   signed-in and write specs skip with a reason and the rest still runs anonymously, which is a useful
   signal on its own. `E2E_LIVE_WRITES` is a repository variable, so writes can be turned off without
   touching code. GitHub disables scheduled workflows after 60 days of repo inactivity.
+
+#### Why the live e2e run cannot reach production from CI
+
+**Cloudflare bot mitigation challenges GitHub-hosted runners, so no live run has ever succeeded.**
+Every scheduled run from the live job landing until the probe below was added failed identically, in
+`globalSetup`, on `GET https://api.typescalegarden.uy/api/fonts answered 403 Forbidden`. That message
+is misleading in the one way that matters: nothing in `server/src/` returns 403 at all. The response
+is Cloudflare's, carries `cf-mitigated: challenge`, and is answered at the edge — **the Worker is
+never reached**, and production serves real visitors normally throughout.
+
+Measured from a runner, it blocks every client the suite could use. This is the table that rules out
+the workarounds, so don't spend an afternoon rediscovering it:
+
+| client                                 | result                                        |
+| -------------------------------------- | --------------------------------------------- |
+| node `fetch` (what `globalSetup` uses) | 403, `cf-mitigated: challenge`                |
+| Playwright's `APIRequestContext`       | 403, `cf-mitigated: challenge`                |
+| `fetch()` inside a real Chromium page  | `TypeError: Failed to fetch`                  |
+| navigating a real Chromium to the app  | 403, a Turnstile page titled "Just a moment…" |
+
+The third row kills the obvious fix of resolving subjects through the browser: a challenge response
+carries no `Access-Control-Allow-Origin`, so the deployed app's own cross-origin call to `/api/fonts`
+fails as an opaque network error no matter how faithfully the request is made — and the app then
+silently falls back to `client/static/fonts-data.json`, a _different_ catalogue, which would turn
+every byte assertion into a confusing diff. The fourth kills it outright: a headless Chromium does not
+clear the interstitial, so the app never boots. Both origins are affected, not just the API
+subdomain. Nothing inside this repo can make a challenged request succeed short of faking the API,
+which is the one thing a live run exists not to do.
+
+So the suite does not pretend otherwise. `e2e/support/challenge.ts` recognises the challenge and
+raises `UnreachableLiveEnvironment` — a distinct type precisely so "this runner cannot reach
+production" is never reported as "production regressed" — and the `live-reachable` job probes for it
+before anything is installed, so a blocked run ends in seconds as a **skip with a stated reason**
+rather than a red X. That matches how the suite already treats missing credentials and a full
+account. `deploy-server.yml`'s smoke test does the same, and this is why it no longer fails a deploy:
+it used to report the challenge as "the deployed Worker is not serving", which was exactly wrong —
+wrangler had already confirmed the upload, and the probe simply cannot run from a runner. The
+trade-off is stated in the comment there: while the challenge is in place a genuinely broken Worker
+would go unreported by that step, but the probe cannot run either way, so failing would only buy a
+permanently red deploy nobody can fix from this repo.
+
+**Lifting it is a Cloudflare-side change, not a code change**, and it is the only thing that turns
+the live layer back on — after which both the probe and the smoke test pass again with no edit here.
+The options, cheapest first:
+
+1. **Turn off Bot Fight Mode for the API**, or scope it away from `api.typescalegarden.uy`. Blunt, but
+   the catalogue endpoint is public, credential-free and GET-only, and the authenticated routes are
+   protected by Auth0 tokens rather than by bot heuristics.
+2. **A WAF custom rule that skips bot mitigation** for a request CI can make and nobody else can —
+   matching a secret header the workflow sends. Narrower, and the one to prefer if the zone's
+   protection is wanted in general. It needs plumbing on this side too: the header on the suite's
+   non-browser fetches _and_ on the browser context, which in turn means the Worker's CORS config has
+   to allow it on the preflight.
+3. **Self-hosted runners**, whose IPs are not in a datacenter range Cloudflare distrusts. Solves it
+   for every check at once and costs the most to operate.
+
+Note that this constraint is separate from — and compounds — the Auth0 concern already noted above:
+automated logins from datacenter IPs are what trip Auth0's attack protection. Both are consequences
+of CI not looking like a person.
 
 #### The rest of CI
 

--- a/e2e/support/challenge.ts
+++ b/e2e/support/challenge.ts
@@ -1,0 +1,107 @@
+/**
+ * Recognising a Cloudflare bot-mitigation challenge, and saying so once.
+ *
+ * Both `typescalegarden.uy` and `api.typescalegarden.uy` sit behind Cloudflare, whose bot
+ * mitigation challenges requests from datacenter IP ranges — which is exactly what a
+ * GitHub-hosted runner has. Every client is affected, not just an unconvincing one:
+ *
+ * ```
+ * node fetch                       → 403, cf-mitigated: challenge
+ * Playwright's APIRequestContext   → 403, cf-mitigated: challenge
+ * fetch() inside a real Chromium   → TypeError: Failed to fetch
+ * navigating a real Chromium       → 403, a Turnstile page titled "Just a moment..."
+ * ```
+ *
+ * The third line is the one that rules out every clever workaround: a challenge response
+ * carries no `Access-Control-Allow-Origin`, so the deployed app's own cross-origin call to
+ * `/api/fonts` fails as an opaque network error however faithfully the request is made. And
+ * the fourth rules out the rest: a headless Chromium does not clear the interstitial, so the
+ * app never boots at all. There is nothing this repo can do about any of it — see CLAUDE.md
+ * for the Cloudflare-side change that lifts it.
+ *
+ * What this module is for is making the *diagnosis* immediate. Left alone the suite reports
+ * `GET https://api.typescalegarden.uy/api/fonts answered 403 Forbidden`, which reads like the
+ * Worker rejecting the request — the one thing it is not, since the challenge is answered at
+ * the edge and the Worker never sees it. `server/src/` contains no 403 at all.
+ */
+
+/**
+ * `cf-mitigated` is the canonical signal and the only one worth branching on: Cloudflare sets
+ * it on every mitigated response, and nothing this repo serves would ever emit it.
+ *
+ * The body markers are a second opinion for the case where the header is stripped by
+ * something in between. They are deliberately not the primary test — "Just a moment" is a
+ * phrase, and matching prose is how a check like this quietly stops working.
+ */
+const BODY_MARKERS = ["__cf_chl", "cf_chl_opt", "challenges.cloudflare.com"];
+
+export interface ChallengeVerdict {
+	challenged: boolean;
+	/** `cf-mitigated`'s value when it was the signal, for the message. */
+	mitigation: string | null;
+}
+
+/**
+ * Whether a response is a challenge rather than an answer.
+ *
+ * `body` is optional because the header alone is usually conclusive and reading a body is
+ * not always free — pass it when it has already been read.
+ */
+export const inspectForChallenge = (
+	headers: { get(name: string): string | null },
+	body?: string
+): ChallengeVerdict => {
+	const mitigated = headers.get("cf-mitigated");
+
+	if (mitigated) return { challenged: true, mitigation: mitigated };
+
+	if (body && BODY_MARKERS.some((marker) => body.includes(marker))) {
+		return { challenged: true, mitigation: null };
+	}
+
+	return { challenged: false, mitigation: null };
+};
+
+/**
+ * Thrown when the live target cannot be reached from *here*, as opposed to being broken.
+ *
+ * The distinction is the whole point of a separate type. A challenge says nothing about the
+ * deployment — production is serving every real visitor perfectly while this is happening —
+ * so it must not be reported as a regression, and `e2e.yml` decides what to do about it by
+ * catching this rather than by pattern-matching a message.
+ */
+export class UnreachableLiveEnvironment extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UnreachableLiveEnvironment";
+	}
+}
+
+/** The one copy of the explanation, so all three call sites say the same thing. */
+export const challengeMessage = (url: string, status: number, mitigation: string | null): string =>
+	[
+		`Cloudflare is challenging this client, so ${url} cannot be reached from here.`,
+		`  ${status}${mitigation ? `, cf-mitigated: ${mitigation}` : ", challenge page in the body"}`,
+		"",
+		"This is not a failure of the deployment: the challenge is answered at Cloudflare's edge",
+		"and the Worker never sees the request. Production is serving real visitors normally.",
+		"",
+		"It is what a GitHub-hosted runner's datacenter IP gets, and it blocks every client —",
+		"node fetch, Playwright's request context, and a real Chromium alike. Lifting it is a",
+		"Cloudflare-side change; CLAUDE.md's \"Why the live e2e run cannot reach production from",
+		'CI" records what to configure.'
+	].join("\n");
+
+/**
+ * The check every non-browser call in a live run funnels through.
+ *
+ * Throws `UnreachableLiveEnvironment` on a challenge and returns otherwise, so a caller's own
+ * error handling stays about its own endpoint.
+ */
+export const throwIfChallenged = (response: Response, url: string, body?: string): void => {
+	const { challenged, mitigation } = inspectForChallenge(response.headers, body);
+
+	if (challenged) {
+		throw new UnreachableLiveEnvironment(challengeMessage(url, response.status, mitigation));
+	}
+};

--- a/e2e/support/liveApi.ts
+++ b/e2e/support/liveApi.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { throwIfChallenged } from "./challenge";
 import { TARGET } from "./target";
 
 /**
@@ -45,12 +46,19 @@ const call = async (
 	method: string,
 	path: string
 ): Promise<{ status: number; typescales?: LiveScale[] }> => {
-	const response = await fetch(`${TARGET.apiUrl}/api${path}`, {
+	const url = `${TARGET.apiUrl}/api${path}`;
+	const response = await fetch(url, {
 		method,
 		headers: { authorization }
 	});
 
-	if (!response.ok) return { status: response.status };
+	if (!response.ok) {
+		// A challenge is not this endpoint answering, so it must not be flattened into a
+		// status the callers below would read as "no headroom" or "nothing saved".
+		throwIfChallenged(response, url);
+
+		return { status: response.status };
+	}
 
 	const body = (await response.json()) as { typescales?: LiveScale[] };
 	return { status: response.status, typescales: body.typescales };

--- a/e2e/support/subjects.ts
+++ b/e2e/support/subjects.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { throwIfChallenged } from "./challenge";
 import type { ApiFont, GoldenFixture, GoldenInputs } from "./golden";
 import { fixture, uiReachableFixtures } from "./golden";
 import { IS_LIVE, TARGET } from "./target";
@@ -132,6 +133,10 @@ export const fetchLiveCatalogue = async (force = false): Promise<LiveCatalogue> 
 		const response = await fetch(url);
 
 		if (!response.ok) {
+			// Before blaming the endpoint: a Cloudflare challenge also arrives as a 403 here,
+			// and it means "this runner cannot reach production", not "the Worker refused".
+			throwIfChallenged(response, url, await response.text().catch(() => ""));
+
 			throw new Error(`GET ${url} answered ${response.status} ${response.statusText}`);
 		}
 


### PR DESCRIPTION
## The failure

The scheduled **live** e2e job has failed **every run since it landed** (2026-08-05 onward), always in `globalSetup`:

```
Error: GET https://api.typescalegarden.uy/api/fonts answered 403 Forbidden
    at ../support/subjects.ts:135
```

That message points at the wrong thing. `server/src/` contains no 403 at all — the response is **Cloudflare's**, carries `cf-mitigated: challenge`, and is answered at the edge. The Worker is never reached, and production serves real visitors normally throughout. It is bot mitigation reacting to a GitHub-hosted runner's datacenter IP.

`deploy-server.yml` fails on the same root cause with a worse symptom: it reported the challenge as `The deployed Worker never answered /api/__liveness — it is not serving` and **failed a deploy that had succeeded**, after dumping 5 kB of Turnstile HTML into the log three times.

## Why there is no code fix

Measured from a real runner (throwaway diagnostic workflow, since none of this reproduces from a residential IP):

| client | result |
| --- | --- |
| node `fetch` (what `globalSetup` uses) | `403`, `cf-mitigated: challenge` |
| Playwright's `APIRequestContext` | `403`, `cf-mitigated: challenge` |
| `fetch()` inside a real Chromium page | `TypeError: Failed to fetch` |
| navigating a real Chromium to the app | `403`, Turnstile page titled `"Just a moment..."` |

Row 3 rules out resolving subjects through the browser: a challenge response carries no `Access-Control-Allow-Origin`, so the app's own cross-origin `/api/fonts` call fails as an opaque network error, and the app then silently falls back to `client/static/fonts-data.json` — a *different* catalogue, which would turn every byte assertion into a confusing diff. Row 4 rules out the rest: headless Chromium does not clear the interstitial, so the app never boots. **Both** origins are affected, not just the API subdomain.

Nothing in this repo can make a challenged request succeed short of faking the API, which is the one thing a live run exists not to do. **Lifting it is a Cloudflare-side change** — the three options are recorded in CLAUDE.md.

## What this PR does

Stops mis-reporting it, and makes the diagnosis immediate:

- **`e2e/support/challenge.ts`** (new) recognises a challenge and raises `UnreachableLiveEnvironment` — a distinct type specifically so "this runner cannot reach production" is never reported as "production regressed". Wired into the catalogue fetch and `liveApi`'s housekeeping calls.
- **A `live-reachable` probe job** gates `live`. It checks nothing out, so a blocked run ends in ~10s as a **skip with a stated reason** instead of a red X — matching how the suite already treats missing credentials and a full account. It self-heals: once the Cloudflare rule lands, the probe passes and `live` runs again with no edit here.
- **`deploy-server.yml`'s smoke test** recognises the challenge, stops blaming the Worker, and stops dumping the interstitial. It **still fails on a genuinely broken Worker** (verified).
- **CLAUDE.md** gains "Why the live e2e run cannot reach production from CI" with the table above and the Cloudflare options.

### The one trade-off, stated plainly

While the challenge is in place, the deploy smoke test passes without having proved anything, so a genuinely broken Worker would go unreported by *that step*. The probe cannot run either way — the only thing failing would buy is a permanently red deploy nobody can fix from this repo. It is commented as such at the call site. The `server` job in `ci.yml` still gates the deploy on `check` + `build`.

## Verification

- `e2e#check` ✅ · `turbo run check lint --filter='!client'` ✅ · prettier ✅
- **Hermetic suite (the PR gate): 47 passed, 3 skipped** ✅ — neither changed module is reachable in hermetic mode (`fetchLiveCatalogue` is only called when `IS_LIVE`; `liveApi` is imported only by live-write specs)
- Challenge detection unit-checked over 6 cases, including a plain 500 HTML error page and a real catalogue body, which must *not* be misread as challenges
- **Both shell probes extracted from the YAML and executed** — the healthy path against the real API, the challenged path, and (for the smoke test) a genuinely broken Worker, confirming it still exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
